### PR TITLE
fin-47: UI) 직업 설정 - 캐릭터 비율

### DIFF
--- a/src/app/menu/user/usertype/page.tsx
+++ b/src/app/menu/user/usertype/page.tsx
@@ -23,8 +23,9 @@ export default function UserTypePage() {
         <Image 
           src={imgPath}
           alt='UserType Image'
-          width={124}
-          height={144}
+          width={120}
+          height={120}
+          priority
         />
       </div>
       <SelectUserType userInfo={userInfo}/>

--- a/src/app/menu/user/usertype/userType.module.css
+++ b/src/app/menu/user/usertype/userType.module.css
@@ -5,9 +5,12 @@
 
 .avatar_box {
     margin: 20px auto 30px;
-    width: 130px;
-    height: 150px;
+    width: 140px;
+    height: 140px;
     border-radius: 20px;
     border: 2px solid #50BF50;
     overflow: hidden;
+    display: flex;
+    justify-content: center;
+    align-items: center;
 }


### PR DESCRIPTION
## 📝 PR 유형

- [ ] 🚀 feature 기능 추가
- [x] 🐞 버그 발생
- [ ] 🔨 리팩토링
- [ ] 📋 문서작성
- [ ] 🌍 빌드 설정 및 문제
- [ ] ETC

## 📝 PR 설명

- UI) 직업 설정 - 캐릭터 비율: 직업 아바타 박스 및 이미지 사이즈 정방향 비율로 수정, 내부 이미지 가운데 정렬, priority 속성 추가

## 관련된 이슈 넘버

<!-- close #1 -->

## ✅ 작업 목록

<!-- 이슈 작업한 내용 -->


## MR하기 전에 확인해주세요

- [ ] local code lint 검사를 진행하셨나요?
- [ ] loca ci test를 진행하셨나요?

## 📚 논의사항

<!-- 이 PR에서 더 논의할 사항 혹은 리뷰어에게 확인 요청하고 싶은 부분 기재 -->

## 📚 ETC

<img width="328" alt="스크린샷 2024-06-23 오후 6 33 49" src="https://github.com/fotcamp/Finhub-FrontEnd/assets/159671505/98422e32-b50c-4aff-9a9a-c2da6d816cdc">

기존에 LCP 요소의 priority 속성이 없어 콘솔 경고가 표시되었습니다. priority 속성 사용 시 이미지 우선 순위 지정으로 성능 향상이 되기 때문에 속성 추가했습니다.
