### PR TITLE
Update fcm token with auto login callback on first web access

### DIFF
--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -1,6 +1,7 @@
 import { ApiResponse } from "@/api/type";
 import { get } from "./client";
 import { deleteToken, setAccessToken, setToken } from "@/utils/authToken";
+import { jsToNative } from "@/utils/jsToNative";
 
 const loginWithKakao = async (kakaoCode: string | null) => {
   const response: ApiResponse = await get(

--- a/src/app/_component/GlobalProvider.tsx
+++ b/src/app/_component/GlobalProvider.tsx
@@ -1,13 +1,18 @@
 "use client";
 
-import { ReactNode } from "react";
+import { FHEventBus } from "@/utils/jsToNative";
+import { ReactNode, useEffect } from "react";
 
 export const GlobalProvider = ({
   children
 }: {
   children:ReactNode
 }) => {
-  
+  useEffect(() => {
+    const eventBus = new FHEventBus();
+
+    eventBus.on('getPushToken', (e) => {});
+  }, []);
 
   return <>{children}</>;
 }

--- a/src/app/_component/GlobalProvider.tsx
+++ b/src/app/_component/GlobalProvider.tsx
@@ -1,0 +1,13 @@
+"use client";
+
+import { ReactNode } from "react";
+
+export const GlobalProvider = ({
+  children
+}: {
+  children:ReactNode
+}) => {
+  
+
+  return <>{children}</>;
+}

--- a/src/app/_component/GlobalProvider.tsx
+++ b/src/app/_component/GlobalProvider.tsx
@@ -1,18 +1,26 @@
 "use client";
 
-import { FHEventBus } from "@/utils/jsToNative";
+import { jsToNative } from "@/utils/jsToNative";
 import { ReactNode, useEffect } from "react";
+import { isLoggedIn } from '@/utils/auth_client';
+import { fcmAPI } from "@/api/fcm";
+import { usePageHistory } from "@/hooks/usePageHistory";
+
 
 export const GlobalProvider = ({
   children
 }: {
   children:ReactNode
 }) => {
-  useEffect(() => {
-    const eventBus = new FHEventBus();
+  const { isFirstVisit } = usePageHistory();
 
-    eventBus.on('getPushToken', (e) => {});
-  }, []);
+  useEffect(() => {
+    if (!isLoggedIn() || !isFirstVisit) return;
+    
+    jsToNative({ val1: "getPushToken" }, (data: any) => {
+      fcmAPI.updateFcmToken(data.detail);
+    });
+  }, [isFirstVisit]);
 
   return <>{children}</>;
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -11,7 +11,6 @@ import Loading from "./loading";
 import { ToastProvider } from "@/components/Toast/ToastProvider";
 
 import localFont from 'next/font/local';
-import { Global } from "@emotion/react";
 import { GlobalProvider } from "./_component/GlobalProvider";
 
 const pretendard = localFont({

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -11,6 +11,8 @@ import Loading from "./loading";
 import { ToastProvider } from "@/components/Toast/ToastProvider";
 
 import localFont from 'next/font/local';
+import { Global } from "@emotion/react";
+import { GlobalProvider } from "./_component/GlobalProvider";
 
 const pretendard = localFont({
   src: '../assets/fonts/PretendardVariable.woff2',
@@ -36,11 +38,13 @@ export default function RootLayout({
         <RecoilRootProvider>
           <RQProvider>
             <MSWComponent />
+            <GlobalProvider>
               <Suspense fallback={<Loading />}>
                 {children}
               </Suspense>
-            <MenuBar />
-            <ToastProvider />
+              <MenuBar />
+              <ToastProvider />
+            </GlobalProvider>
           </RQProvider>
         </RecoilRootProvider>
         <div id="toast-portal" />

--- a/src/hooks/usePageHistory.ts
+++ b/src/hooks/usePageHistory.ts
@@ -1,0 +1,16 @@
+import { useEffect, useMemo } from 'react';
+import { usePathname, useSearchParams } from 'next/navigation';
+import { useRecoilState } from 'recoil';
+import { historyPathsState } from '@/states/client/atoms/history';
+
+export const usePageHistory = () => {
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+  const [historyPaths, setHistoryPathsState] = useRecoilState(historyPathsState);
+
+  useEffect(() => {
+    setHistoryPathsState((prev: string[]) => [...prev, pathname + searchParams.toString()]);
+  }, [pathname, searchParams, setHistoryPathsState]);
+
+  return { isFirstVisit: !historyPaths.length, historyPaths };
+};

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,33 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server'
-import { getToken } from './utils/auth_server';
-
-const API_BASE_URL = process.env.NEXT_PUBLIC_API_MOCKING === 'enabled' ? 'http://localhost:9090' : process.env.NEXT_PUBLIC_BASE_URL;
 
 export async function middleware(request: NextRequest) {
-
-  const tokens = getToken();
-  function autoLogin() {
-    fetch(`${API_BASE_URL}/api/v1/auth/autoLogin`, {
-      method: "GET",
-      headers: {
-        "Content-Type": "application/json",
-        finhub: process.env.NEXT_PUBLIC_API_KEY || "",
-        Authorization: `Bearer ${tokens.accessToken}`,
-        refreshToken: `${tokens.refreshToken}`,
-      },
-      cache: "no-store",
-      credentials: "include"
-    })
-    .then(response => {
-      return response.json();
-    })
-    .then(data => {
-      console.log("Auto Login: ", data);
-    });
-  }
-
-  autoLogin();
-
   return NextResponse.redirect(new URL('/home', request.url));
 }
 

--- a/src/states/client/atoms/history.ts
+++ b/src/states/client/atoms/history.ts
@@ -1,0 +1,6 @@
+import { atom } from "recoil";
+
+export const historyPathsState = atom<string[]>({
+  key: "historyPathsState",
+  default: [],
+});

--- a/src/utils/jsToNative.ts
+++ b/src/utils/jsToNative.ts
@@ -6,7 +6,7 @@ declare global {
 }
 
 type EventHandler = (payload: any) => void;
-class FHEventBus {
+export class FHEventBus {
   static uniqueIdSet = new Set<string>();
   static generateUniqueId(prefix: string): string {
     let id: string;


### PR DESCRIPTION
## 📝 PR 유형

- [x] 🚀 feature 기능 추가
- [ ] 🐞 버그 발생
- [ ] 🔨 리팩토링
- [ ] 📋 문서작성
- [ ] 🌍 빌드 설정 및 문제
- [ ] ETC

## 📝 PR 설명
- login 관리 주체가 웹이기 때문에 웹에서 관리하도록 구현하였습니다.
- /post -> /post/1 -> /post일때 재접근을 한 것이라고 판단하기 때문에 stack을 구현하여 판단하였습니다.

```ts
export const usePageHistory = () => {
  const pathname = usePathname();
  const searchParams = useSearchParams();
  const [historyPaths, setHistoryPathsState] = useRecoilState(historyPathsState);

  useEffect(() => {
    setHistoryPathsState((prev: string[]) => [...prev, pathname + searchParams.toString()]);
  }, [pathname, searchParams, setHistoryPathsState]);

  return { isFirstVisit: !historyPaths.length, historyPaths };
};
```

<!-- PR 설명 -->

## 관련된 이슈 넘버

<!-- close #1 -->

## ✅ 작업 목록

<!-- 이슈 작업한 내용 -->

- 작업1

## MR하기 전에 확인해주세요

- [ ] local code lint 검사를 진행하셨나요?
- [ ] loca ci test를 진행하셨나요?

## 📚 논의사항

<!-- 이 PR에서 더 논의할 사항 혹은 리뷰어에게 확인 요청하고 싶은 부분 기재 -->

## 📚 ETC

<!-- Screenshot, References 기재 -->
