### PR TITLE
FIN-110: 퀴즈 토픽 해시태그 > 토픽 상세 >뒤로가기시 다시 퀴즈 팝업으로 돌아오게 요청

### DIFF
--- a/src/app/_component/GlobalProvider.tsx
+++ b/src/app/_component/GlobalProvider.tsx
@@ -2,6 +2,7 @@
 
 import { ReactNode } from "react";
 import { useAutoLogin } from "@/hooks/useAutoLogin";
+import { useCacheControl } from "@/hooks/useCacheControl";
 
 
 export const GlobalProvider = ({
@@ -10,6 +11,7 @@ export const GlobalProvider = ({
   children:ReactNode
 }) => {
   useAutoLogin();
+  useCacheControl();
 
   return <>{children}</>;
 }

--- a/src/app/feed/quiz/_component/QuizList.tsx
+++ b/src/app/feed/quiz/_component/QuizList.tsx
@@ -69,7 +69,8 @@ export default function QuizList() {
     quizResultPopupModal,
     handleQuizItemClick,
     handleQuizResultClose,
-    handleAnswerClick
+    handleAnswerClick,
+    handleClickTag,
   } = useSolveQuizHook();
 
   if (isLoading) return <Loading height={300} />;
@@ -123,6 +124,7 @@ export default function QuizList() {
           onClose={handleQuizResultClose}
           quizResult={selectedQuizRusult}
           onSolveOtherClick={handleQuizResultClose}
+          onTagClick={handleClickTag}
         />
       }
     </Fragment>

--- a/src/app/feed/quiz/_component/QuizResult.tsx
+++ b/src/app/feed/quiz/_component/QuizResult.tsx
@@ -7,9 +7,7 @@ import { Box } from '@/components/Box';
 import { FlexBox } from '@/components/FlexBox';
 import { Text } from '@/components/Text';
 import { Button } from '@/components/Button';
-import { useRouter } from 'next/navigation';
 import { Stack } from '@/components/Stack';
-import { LinkButton } from '@/components/LinkButton';
 
 import PenIcon from '@/public/quiz/quiz_pen_icon.svg';
 
@@ -17,15 +15,17 @@ interface Props {
   show: boolean,
   onClose: () => void
   quizResult: QuizSolveUser;
-  onSolveOtherClick?: () => void,
+  onTagClick: (url: string) => void;
+  onSolveOtherClick: () => void,
 }
 
-export const QuizResult = ({ show, onClose, quizResult, onSolveOtherClick }: Props) => {
-  const router = useRouter();
-
+export const QuizResult = ({ show, onClose, quizResult, onTagClick, onSolveOtherClick }: Props) => {
   const handleOtherQuizClick = () => {
-    if (onSolveOtherClick) return onSolveOtherClick();
-    router.push('/feed/quiz')
+    onSolveOtherClick();
+  }
+
+  const handleClickTag = (url: string) => {
+    onTagClick(url);
   }
 
   return (
@@ -53,11 +53,11 @@ export const QuizResult = ({ show, onClose, quizResult, onSolveOtherClick }: Pro
 
           <FlexBox mt={13} gap={12} flexWrap='wrap'>
             {quizResult.topicList.map((item, index) => (
-              <LinkButton key={index} href={`/${item.categoryId}/${item.topicId}`} >
+              <Button key={index}  onClick={() => handleClickTag(`/${item.categoryId}/${item.topicId}`)} >
                 <Box key={index} radius={10} px={10} backgroundColor='#50BF50'>
                   <Text size={12} weight={600} color='#F9FAFA' lineHeight='32px'># {item.title}</Text>
                 </Box>
-              </LinkButton>
+              </Button>
 
             ))}
           </FlexBox>

--- a/src/app/feed/quiz/detail/_component/QuizDetailScreen.tsx
+++ b/src/app/feed/quiz/detail/_component/QuizDetailScreen.tsx
@@ -58,6 +58,8 @@ export const QuizDetailScreen = () => {
     handleQuizItemClick,
     handleQuizResultClose,
     handleAnswerClick,
+    quizResultCache,
+    handleClickTag,
   } = useSolveQuizHook();
 
   useEffect(() => {
@@ -135,6 +137,7 @@ export const QuizDetailScreen = () => {
           onClose={handleQuizResultClose}
           quizResult={selectedQuizRusult}
           onSolveOtherClick={handleQuizResultClose}
+          onTagClick={handleClickTag}
         />
       }
 

--- a/src/app/feed/quiz/detail/_component/QuizDetailScreen.tsx
+++ b/src/app/feed/quiz/detail/_component/QuizDetailScreen.tsx
@@ -58,7 +58,6 @@ export const QuizDetailScreen = () => {
     handleQuizItemClick,
     handleQuizResultClose,
     handleAnswerClick,
-    quizResultCache,
     handleClickTag,
   } = useSolveQuizHook();
 

--- a/src/hooks/useCache.ts
+++ b/src/hooks/useCache.ts
@@ -1,0 +1,26 @@
+import { useRecoilState } from 'recoil';
+import { cacheState } from '@/states/client/atoms/cache';
+
+export function useCache<T = any>() {
+  const [cache, setCache] = useRecoilState(cacheState);
+
+  const get = (key: string): T | undefined => {
+    return cache[key] as T | undefined;
+  };
+
+  const set = (key: string, value: T) => {
+    setCache(prevCache => ({
+      ...prevCache,
+      [key]: value
+    }));
+  };
+
+  const clear = (key: string) => {
+    setCache(prevCache => {
+      const { [key]: _, ...rest } = prevCache;
+      return rest;
+    });
+  };
+
+  return { get, set, clear };
+}

--- a/src/hooks/useCacheControl.ts
+++ b/src/hooks/useCacheControl.ts
@@ -1,0 +1,31 @@
+import { quizResultCacheState } from "@/states/client/atoms/cache"
+import { historyPathsState } from "@/states/client/atoms/history";
+import { useQueryClient } from "@tanstack/react-query";
+import { useEffect } from "react";
+import { useRecoilState, useRecoilValue, useSetRecoilState } from "recoil"
+
+export const useCacheControl = () => {
+  const historyPaths = useRecoilValue(historyPathsState);
+  
+  /** Quiz Result tag 이동 후 뒤로가지 않은 경우 */
+  const [quizResultCache, setQuizResultCache] = useRecoilState(quizResultCacheState);
+  const queryClient = useQueryClient();
+  const verifyQuizResultExitWithoutBack = (startPath?: string) => {
+    if (!startPath) return;
+
+    if (
+      historyPaths.at(-3) === startPath &&
+      historyPaths.at(-1) !== startPath
+    ) {
+      if (startPath === "/feed") {
+        queryClient.invalidateQueries({ queryKey: ["quiz"]}); 
+      }
+
+      setQuizResultCache(null);
+    }
+  }
+
+  useEffect(() => {
+    verifyQuizResultExitWithoutBack(quizResultCache?.startPath);
+  }, [historyPaths]);
+}

--- a/src/hooks/useCacheControl.ts
+++ b/src/hooks/useCacheControl.ts
@@ -1,15 +1,19 @@
-import { quizResultCacheState } from "@/states/client/atoms/cache"
 import { historyPathsState } from "@/states/client/atoms/history";
 import { useQueryClient } from "@tanstack/react-query";
 import { useEffect } from "react";
-import { useRecoilState, useRecoilValue, useSetRecoilState } from "recoil"
+import { useRecoilValue } from "recoil"
+import { useCache } from "./useCache";
+
+export const CACHE_KEY = {
+  quizResult: "quizResult"
+} as const;
 
 export const useCacheControl = () => {
-  const historyPaths = useRecoilValue(historyPathsState);
-  
-  /** Quiz Result tag 이동 후 뒤로가지 않은 경우 */
-  const [quizResultCache, setQuizResultCache] = useRecoilState(quizResultCacheState);
+  const { get, clear } = useCache();
   const queryClient = useQueryClient();
+  const historyPaths = useRecoilValue(historyPathsState);
+
+  /** Quiz Result tag 이동 후 뒤로가지 않은 경우 */
   const verifyQuizResultExitWithoutBack = (startPath?: string) => {
     if (!startPath) return;
 
@@ -18,14 +22,14 @@ export const useCacheControl = () => {
       historyPaths.at(-1) !== startPath
     ) {
       if (startPath === "/feed") {
-        queryClient.invalidateQueries({ queryKey: ["quiz"]}); 
+        queryClient.invalidateQueries({ queryKey: ["quiz"] });
       }
 
-      setQuizResultCache(null);
+      clear(CACHE_KEY.quizResult);
     }
   }
 
   useEffect(() => {
-    verifyQuizResultExitWithoutBack(quizResultCache?.startPath);
+    verifyQuizResultExitWithoutBack(get(CACHE_KEY.quizResult)?.startPath);
   }, [historyPaths]);
 }

--- a/src/states/client/atoms/cache.ts
+++ b/src/states/client/atoms/cache.ts
@@ -1,7 +1,10 @@
-import { QuizSolveUser } from "@/model/QuizSolveUser";
 import { atom } from "recoil";
 
-export const quizResultCacheState = atom<QuizSolveUser & {startPath: string} | null>({
-  key: "quizResultCache",
-  default: null
+type CacheStateType = {
+  [key: string]: any;
+}
+
+export const cacheState = atom<CacheStateType>({
+  key: "cacheState",
+  default: {}
 })

--- a/src/states/client/atoms/cache.ts
+++ b/src/states/client/atoms/cache.ts
@@ -1,0 +1,7 @@
+import { QuizSolveUser } from "@/model/QuizSolveUser";
+import { atom } from "recoil";
+
+export const quizResultCacheState = atom<QuizSolveUser & {startPath: string} | null>({
+  key: "quizResultCache",
+  default: null
+})


### PR DESCRIPTION
## 📝 PR 유형

- [x] 🚀 feature 기능 추가
- [ ] 🐞 버그 발생
- [ ] 🔨 리팩토링
- [ ] 📋 문서작성
- [ ] 🌍 빌드 설정 및 문제
- [ ] ETC

## 📝 PR 설명
- FIN-110
<!-- PR 설명 -->

## 관련된 이슈 넘버
- FIN-110
<!-- close #1 -->

## ✅ 작업 목록

<!-- 이슈 작업한 내용 -->

- quiz 페이지에서 퀴즈 결과 팝업을 띄운 뒤 tag를 눌러 페이지 이동 후 되돌아 왔을 때 state 유지를 위해 recoil 사용
- 뒤로가기로 이동이 아닌 이탈 시 다실 돌아올경우에는 띄우면 안되는 상황으로 인해 useCacheControl 사용
- useCacheControl 에서 historyPath로 뒤로가기 이탈의 경우를 판단

## MR하기 전에 확인해주세요

- [ ] local code lint 검사를 진행하셨나요?
- [ ] loca ci test를 진행하셨나요?

## 📚 논의사항

<!-- 이 PR에서 더 논의할 사항 혹은 리뷰어에게 확인 요청하고 싶은 부분 기재 -->

## 📚 ETC

<!-- Screenshot, References 기재 -->
