### PR TITLE
FIN-151: 닉네임 설정 안하고 칼럼 댓글 입력 시 "닉네임 설정 필요" 토스트 팝업에 "설정하기" 버튼 추가

### DIFF
--- a/src/app/feed/column/[columnId]/comment/post/_component/PostCommentScreen.tsx
+++ b/src/app/feed/column/[columnId]/comment/post/_component/PostCommentScreen.tsx
@@ -11,7 +11,9 @@ import { useEditGptColumnComment, useGptColumnComment } from "@/states/server/mu
 
 import { AppBar } from "@/components/AppBar";
 import { Box } from "@/components/Box";
+import { Button } from "@/components/Button";
 import { AppContainer, Container } from "@/components/Container";
+import { FlexRow } from "@/components/FlexRow";
 import { Text } from "@/components/Text";
 import { useToast } from "@/components/Toast/useToast";
 
@@ -37,11 +39,39 @@ export const PostCommentScreen = () => {
     if (commentPostType === COMMENT_POST_TYPE.edit) setComment(editInitComment);
   }, [editInitComment]);
 
+  const handleMoveNickNameMenu = () => {
+    router.push("/menu/user/name");
+  };
+
   const postCommentMutation = useGptColumnComment({
     onSuccess: data => {
       if (data.status === "FAIL") {
-        showToast({ content: data.errorMsg, type: "warning" });
-        return;
+        if (data.errorMsg === "닉네임 설정 필요") {
+          showToast({
+            content: (
+              <FlexRow>
+                <Text>닉네임 설정이 필요해요!</Text>
+                <Button
+                  py={10}
+                  px={12}
+                  radius={6}
+                  textColor="#FFF"
+                  backgroundColor="#494F54"
+                  onClick={handleMoveNickNameMenu}
+                  style={{ pointerEvents: "auto" }}
+                >
+                  설정하기
+                </Button>
+              </FlexRow>
+            ),
+            type: "warning",
+            duration: 4000
+          });
+          return;
+        } else {
+          showToast({ content: data.errorMsg, type: "warning" });
+          return;
+        }
       }
 
       queryClient.invalidateQueries({ queryKey: ["gptColumnComment"] });


### PR DESCRIPTION
## 📝 PR 유형

- [x] 🚀 feature 기능 추가
- [ ] 🐞 버그 발생
- [ ] 🔨 리팩토링
- [ ] 📋 문서작성
- [ ] 🌍 빌드 설정 및 문제
- [ ] ETC

## 📝 PR 설명
FIN-151: 닉네임 설정 안하고 칼럼 댓글 입력 시 "닉네임 설정 필요" 토스트 팝업에 "설정하기" 버튼 추가
<!-- PR 설명 -->

## 관련된 이슈 넘버
https://fin-hub.atlassian.net/browse/FIN-151?atlOrigin=eyJpIjoiMTc0MjI3YTNkYjcxNDE0Y2E5MjM1ZmMxZjg5YTNmNmEiLCJwIjoiaiJ9
<!-- close #1 -->

## ✅ 작업 목록

<!-- 이슈 작업한 내용 -->

- 컬럼 댓글 페이지 Toast 설정하기 버튼 추가 (닉네임 설정)

## MR하기 전에 확인해주세요

- [x] local code lint 검사를 진행하셨나요?
- [ ] loca ci test를 진행하셨나요?

## 📚 논의사항

<!-- 이 PR에서 더 논의할 사항 혹은 리뷰어에게 확인 요청하고 싶은 부분 기재 -->

## 📚 ETC

<!-- Screenshot, References 기재 -->
